### PR TITLE
re-enable the "Craft all" button

### DIFF
--- a/minetest.conf
+++ b/minetest.conf
@@ -55,7 +55,7 @@ bridger_enable_trusses = true
 pipeworks_max_items_per_tube = 60
 
 # unified inv+
-unified_inventory_plus.enable_craft_all = false
+unified_inventory_plus.enable_craft_all = true
 
 # currency
 currency.income_enabled = false


### PR DESCRIPTION
may mitigate #543 in combination with disabled xp-rewards on "high-stacking" items