### PR TITLE
Add `beacon_area_shielding` setting

### DIFF
--- a/minetest.conf
+++ b/minetest.conf
@@ -45,8 +45,9 @@ areas.self_protection_privilege = areas_protect
 areas.self_protection_max_areas = 1000
 areas.self_protection_max_areas_high = 1500
 
-# beacon default effect
+# beacon
 beacon_default_effect = fly
+beacon_area_shielding = true
 
 # bridger
 bridger_enable_trusses = true


### PR DESCRIPTION
Adds the new `beacon_area_shielding` setting for https://github.com/OgelGames/beacon/issues/11, the default is false for compatibility with old beacon mod.