### PR TITLE
share postgres socket with minetest instance

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
    - "./data/minetest/debug.txt:/root/.minetest/debug.txt"
    - "./config/metatool.cfg:/data/world/metatool.cfg"
    - "./data/pandorabox-textures:/root/.minetest/textures/server"
+   - "postgres_socket:/var/run/postgresql"
   logging:
    options:
     max-size: 50m
@@ -28,6 +29,7 @@ services:
    POSTGRES_PASSWORD: enter
   volumes:
    - "./data/postgres:/var/lib/postgresql/data"
+   - "postgres_socket:/var/run/postgresql"
   command:
    - "postgres"
    - "-c"
@@ -207,6 +209,9 @@ services:
   logging:
    options:
     max-size: 50m
+
+volumes:
+  postgres_socket: {}
 
 networks:
  terminator:


### PR DESCRIPTION
Allows the minetest server to use the postgres socket instead of going through the tcp stack.

Todo:
* [x] update `world.mt` with new connection strings

## world.mt
```
pgsql_connection = host=/var/run/postgresql user=postgres password=* dbname=postgres
pgsql_auth_connection = host=/var/run/postgresql user=postgres password=* dbname=postgres
pgsql_player_connection = host=/var/run/postgresql user=postgres password=* dbname=postgres
```

@verymilan thank you for the idea :smile: i tried that on the test-instance, looks good so far :+1:, i'm letting you know if there's a performance benefit