### PR TITLE
set tubetool machine_use_priv to interact

### DIFF
--- a/config/metatool.cfg
+++ b/config/metatool.cfg
@@ -1,3 +1,3 @@
 metatool:luatool:machine_use_priv = staff
-metatool:tubetool:machine_use_priv = staff
+metatool:tubetool:machine_use_priv = interact
 metatool:sharetool:machine_use_priv = staff


### PR DESCRIPTION
Allows anyone to use tubetool with nodebreaker.

I think this should be safe, allows reconfiguring tube devices automatically with node breaker.