### PR TITLE
expose minetest engine port to "terminator" network (ipv6 capable)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,9 @@ services:
  minetest:
   image: buckaroobanzay/minetest:5.3.0-r5
   restart: always
+  networks:
+   - terminator
+   - default
   ports:
    - "30000:30000/udp"
   depends_on:

--- a/minetest.conf
+++ b/minetest.conf
@@ -136,6 +136,7 @@ server_url = https://pandorabox.io
 server_announce = true
 serverlist_url = servers.minetest.net
 port = 30000
+ipv6_server = true
 disallow_empty_password = true
 disable_anticheat = true
 ask_reconnect_on_crash = true


### PR DESCRIPTION
related (but already closed): https://github.com/pandorabox-io/pandorabox.io/issues/312

This _will_ restart the server after merging