### PR TITLE
Update engine to 5.3.0-r7 with backported experimental patches

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ version: "2"
 
 services:
  minetest:
-  image: buckaroobanzay/minetest:5.3.0-r5
+  image: buckaroobanzay/minetest:5.3.0-r7
   restart: always
   networks:
    - terminator


### PR DESCRIPTION
Updates the minetest engine to an image with following patches:
https://github.com/pandorabox-io/minetest_docker/commit/6bcf817ca3d5f5267fc5f522076f5feef3b9cb06

**Note**: this is based on the same engine commit as the current engine version (`5.3.0`), no changes there, `5.4.0` isn't ready yet it seems...

## Features
* only send mapblocks every 3rd globalstep (prevents some sends due to busy mesecons/vmanips)
* removed 2 (IMO) unneeded set-timestamps sets on mapblocks

The first change is unproblematic but may deduplicate some mapblocks sends on the server (performance)
The second change removes some settimestamp calls that caused quite the heavy mapblock traffic on both database and network. I tested this pretty thorough but it may still have some bugs in it.

I'm merging that the next time i'm online for a longer time, if anything backfires it can be reverted again without a trace.