### PR TITLE
update to minetest engine 5.4.0-r1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ version: "2"
 
 services:
  minetest:
-  image: buckaroobanzay/minetest:5.3.0-r7
+  image: buckaroobanzay/minetest:5.4.0-r1
   restart: always
   networks:
    - terminator


### PR DESCRIPTION
patched like #620 but with `5.4.0` as base


## Custom features
* only send mapblocks every 2nd globalstep (prevents some sends due to busy mesecons/vmanips)
* removed 2 (IMO) unneeded set-timestamps sets on mapblocks
* removed (custom) async map saving (should now perform better because we have less changed mapblocks)
* Engine metrics: https://monitoring.minetest.land/d/BRwIg8xMz/engine-metrics?orgId=1&refresh=5s&var-instance=test.pandorabox.io:443

Applied patches:  pandorabox-io/minetest_docker@6bcf817