### PR TITLE
switch to minetest 5.4.0-r3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ version: "2"
 
 services:
  minetest:
-  image: buckaroobanzay/minetest:5.4.0-r2
+  image: buckaroobanzay/minetest:5.4.0-r3
   restart: always
   networks:
    - terminator


### PR DESCRIPTION
switches to engine `5.4.0-r3` with some more threading-shenanigans, live on `test.pandorabox.io`

https://github.com/pandorabox-io/minetest_docker/compare/5.4.0-r2...5.4.0-r3