### PR TITLE
Playerfactions config

### DIFF
--- a/minetest.conf
+++ b/minetest.conf
@@ -115,6 +115,9 @@ prometheus_listener_address = 0.0.0.0:8080
 # mobs
 mob_nospawn_range = 8
 
+# playerfactions
+player_factions.mode_unique_faction = false
+
 # protector
 protector_pvp = true
 


### PR DESCRIPTION
Allow multiple factions. Single faction / player is not really that useful at pandorabox where overlapping communities are created instead of isolated groups.
Also I think this was like that long ago? Settings lost when config moved from separate file to minetest conf file?