### PR TITLE
fs51 disable metadata formspec rewrite

### DIFF
--- a/minetest.conf
+++ b/minetest.conf
@@ -17,6 +17,9 @@ advtrains_forgiving_collision = true
 # hotbar defaults
 hotbar_size = 8
 
+# fs51 https://github.com/pandorabox-io/pandorabox-mods/pull/2244
+fs51.disable_meta_override = true
+
 # headlamp
 headlamp_battery_life = 60
 


### PR DESCRIPTION
See https://github.com/pandorabox-io/pandorabox-mods/pull/2244

Metadata formspec rewrites apparently causes problems with touchscreen user interfaces.