### PR TITLE
Allow magic_pen, containertool and tronwrench in machines

### DIFF
--- a/config/metatool.cfg
+++ b/config/metatool.cfg
@@ -1,3 +1,6 @@
 metatool:luatool:machine_use_priv = interact
 metatool:tubetool:machine_use_priv = interact
+metatool:containertool:machine_use_priv = interact
+metatool:tronwrench:machine_use_priv = interact
+metatool:magic_pen:machine_use_priv = interact
 metatool:sharetool:machine_use_priv = staff


### PR DESCRIPTION
Not sure if this is safe for all things but fairly easy to disable if there's problems.
Of course could be tested on test server, default required privilege is `server`