### PR TITLE
add mtui

### DIFF
--- a/data/nginx/routes/ui.conf
+++ b/data/nginx/routes/ui.conf
@@ -1,0 +1,9 @@
+location /ui/ {
+	proxy_pass http://ui:8080/;
+	proxy_buffering off;
+	proxy_http_version 1.1;
+	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+	proxy_set_header Upgrade $http_upgrade;
+	proxy_set_header Connection $http_connection;
+	access_log off;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,17 @@ services:
    options:
     max-size: 50m
 
+ ui:
+  image: buckaroobanzay/mtui:1.2
+  environment:
+   WORLD_DIR: "/data/world"
+   COOKIE_DOMAIN: "pandorabox.io"
+   COOKIE_SECURE: "true"
+   COOKIE_PATH: "/ui"
+  volumes:
+   - "./data/minetest:/data"
+   - "postgres_socket:/var/run/postgresql"
+
  postgres-exporter:
   image: wrouesnel/postgres_exporter:v0.8.0
   restart: always
@@ -108,11 +119,7 @@ services:
    - kv
    - nodered
    - postgres-exporter
-  environment:
-   VIRTUAL_PORT: 80
-   VIRTUAL_HOST: pandorabox.io
-   LETSENCRYPT_HOST: pandorabox.io
-   LETSENCRYPT_EMAIL: thomas@rudin.io
+   - ui
   labels:
     - "traefik.enable=true"
     - "traefik.docker.network=terminator"

--- a/minetest.conf
+++ b/minetest.conf
@@ -112,6 +112,9 @@ mapserver.enable_crafting = true
 # webmail
 webmail.url = http://webmail:8080
 
+# ui url
+mtui.url = http://ui:8080
+
 # auth-proxy (wiki)
 auth_proxy.url = http://auth-proxy:8080
 


### PR DESCRIPTION
this adds the `mtui` web interface on https://pandorabox.io/ui/

Demo here: https://test.pandorabox.io/ui/ (feel free to pentest that:)
Source: https://github.com/minetest-go/mtui

Currently it allows players to:
* Log in (via password or tan)
* Check their privs
* Check and compose mails
* Reset their password
* Send commands to ingame
* See the online players and some infos about them (only for those with `ban` priv)

This project aims to make the following obsolete:
* [x] Webmail: https://github.com/minetest-mail/mail (has feature-parity)
* [ ] Auth-proxy: https://github.com/minetest-auth-proxy/auth_proxy_app (needs some changes to the mediawiki plugin)

Maybe even the `beerchat-proxy` in its current form some day (see #699)
