### PR TITLE
Allow staff to read QoS stats

### DIFF
--- a/minetest.conf
+++ b/minetest.conf
@@ -6,6 +6,8 @@ secure.http_mods = monitoring,mail,mapserver,auth_proxy_mod,geoip,beerchat,xp_re
 
 curl_timeout = 10000
 
+qos.info_priv = staff
+
 # locally hosted media server
 enable_remote_media_server = true
 remote_media = https://pandorabox.io/media/


### PR DESCRIPTION
```
# Return current QoS queue length
/qos:queue_length [<priority>]

# Return number of active requests executed with QoS controller
/qos:active_requests

# Return current QoS active requests utilization  percentage value
/qos:active_utilization

# Return current QoS queue utilization percentage value
/qos:utilization [<priority>]
```