### PR TITLE
remove webmail, redirect to /ui

### DIFF
--- a/data/nginx/routes/webmail.conf
+++ b/data/nginx/routes/webmail.conf
@@ -1,13 +1,3 @@
 location /webmail/ {
-	resolver 127.0.0.11 valid=30s;
-	set $upstream_host webmail;
-	proxy_pass http://$upstream_host:8080;
-	rewrite /webmail(.*) $1 break;
-
-	proxy_buffering off;
-	proxy_http_version 1.1;
-	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-	proxy_set_header Upgrade $http_upgrade;
-	proxy_set_header Connection $http_connection;
-	access_log off;
+	return 301 /ui/;
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,7 +104,6 @@ services:
   depends_on:
    - highscore
    - mapserver
-   - webmail
    - wiki
    - kv
    - nodered
@@ -140,12 +139,6 @@ services:
    PGDATABASE: postgres
    PGPASSWORD: enter
    PGPORT: 5432
-
- webmail:
-  image: minetestmail/mail:1.2
-  restart: always
-  depends_on:
-   - minetest
 
  manager:
   image: buckaroobanzay/minetest_manager

--- a/minetest.conf
+++ b/minetest.conf
@@ -2,7 +2,7 @@
 server_name = Pandorabox
 
 # http mods
-secure.http_mods = monitoring,mail,mapserver,auth_proxy_mod,geoip,beerchat,xp_redo,digistuff,blockexchange,mtui
+secure.http_mods = monitoring,mapserver,auth_proxy_mod,geoip,beerchat,xp_redo,digistuff,blockexchange,mtui
 
 curl_timeout = 10000
 
@@ -110,9 +110,6 @@ digtron_cycle_time = 1.0
 # mapserver
 mapserver.url = http://mapserver:8080
 mapserver.enable_crafting = true
-
-# webmail
-webmail.url = http://webmail:8080
 
 # ui url
 mtui.url = http://ui:8080


### PR DESCRIPTION
The webmail service will be removed and replaced by the new `mtui` which should provide the same features at this point