### PR TITLE
add `lua` channel

### DIFF
--- a/config/matterbridge.toml
+++ b/config/matterbridge.toml
@@ -77,6 +77,19 @@ account="api.minetest"
 channel="api"
 
 [[gateway]]
+name="lua"
+enable=true
+[[gateway.inout]]
+account="irc.Libera"
+channel="#pandorabox-lua"
+[[gateway.inout]]
+account = "discord.Discord"
+channel="lua"
+[[gateway.inout]]
+account="api.minetest"
+channel="api"
+
+[[gateway]]
 name="de"
 enable=true
 [[gateway.inout]]


### PR DESCRIPTION
bridges the `#lua` channel from ingame to discord and irc (as discussed in `#ideas`)

TODO:
* [x] create a `#lua` channel in the discord server