### PR TITLE
add anubis and botpolicy

### DIFF
--- a/botPolicy.yaml
+++ b/botPolicy.yaml
@@ -1,0 +1,56 @@
+# https://github.com/TecharoHQ/anubis/tree/main/data
+
+bots:
+  - name: custom-bots
+    action: DENY
+    expression:
+     any:
+      - userAgent.startsWith("meta-webindexer")
+  
+  - name: ddos-range-AS63179-twitter
+    action: DENY
+    remote_addresses:
+      [
+        "69.12.59.0/24",
+        "192.48.237.0/24",
+        "69.12.60.0/24",
+        "192.48.236.0/24",
+        "69.12.58.0/24",
+        "69.12.62.0/24",
+        "69.12.63.0/24",
+        "69.12.57.0/24",
+        "69.12.56.0/21",
+        "69.12.56.0/24",
+        "69.12.61.0/24"
+      ]
+
+  - import: (data)/clients/x-firefox-ai.yaml
+  - import: (data)/clients/git.yaml
+  - import: (data)/bots/_deny-pathological.yaml
+  - import: (data)/bots/aggressive-brazilian-scrapers.yaml
+  - import: (data)/meta/ai-block-aggressive.yaml
+  - import: (data)/crawlers/_allow-good.yaml
+  - import: (data)/common/keep-internet-working.yaml
+
+thresholds:
+  - name: minimal-suspicion
+    expression: weight < 0
+    action: ALLOW
+
+  - name: issue-challenge
+    expression: weight >= 5
+    action: CHALLENGE
+    challenge:
+      algorithm: fast
+      difficulty: 3
+
+dnsbl: false
+
+status_codes:
+  CHALLENGE: 200
+  DENY: 200
+
+store:
+  backend: bbolt
+  parameters:
+    path: /data/anubis.bdb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,35 +98,6 @@ services:
    - "./data/wiki/images:/var/www/html/images"
    - "./config/LocalSettings.php:/var/www/html/LocalSettings.php"
    - "./data/wiki/LocalSettings.secrets.php:/var/www/html/LocalSettings.secrets.php"
-
-  logging:
-   options:
-    max-size: 50m
-
- nginx:
-  image: nginx:1.30.0
-  networks:
-   - terminator
-   - default
-  restart: always
-  depends_on:
-   - highscore
-   - mapserver
-   - wiki
-   - kv
-   - nodered
-   - ui
-  labels:
-   - "traefik.enable=true"
-   - "traefik.docker.network=terminator"
-   - "traefik.http.routers.pandorabox.rule=Host(`pandorabox.io`)"
-   - "traefik.http.services.pandorabox.loadbalancer.server.port=80"
-   - "traefik.http.routers.pandorabox.entrypoints=websecure"
-   - "traefik.http.routers.pandorabox.tls.certresolver=default"
-  volumes:
-   - "./config/nginx.conf:/etc/nginx/nginx.conf:ro"
-   - "./data/backup:/backup"
-   - "./data/crashlogs:/crashlogs"
   logging:
    options:
     max-size: 50m
@@ -188,6 +159,58 @@ services:
    - "postgres"
   working_dir: /data/world
 
+ pandorabox-nginx:
+  image: nginx:1.30.0
+  restart: always
+  depends_on:
+   - highscore
+   - mapserver
+   - wiki
+   - kv
+   - nodered
+   - ui
+   - minetest
+  volumes:
+   - "./config/nginx.conf:/etc/nginx/nginx.conf:ro"
+   - "./data/backup:/backup"
+   - "./data/crashlogs:/crashlogs"
+
+ pandorabox-anubis:
+   image: ghcr.io/techarohq/anubis:v1.25.0
+   networks:
+    - terminator
+    - default
+   depends_on:
+    - pandorabox-nginx
+   restart: always
+   environment:
+     BIND: ":8080"
+     DIFFICULTY: "4"
+     METRICS_BIND: ":9090"
+     SERVE_ROBOTS_TXT: "true"
+     COOKIE_DOMAIN: "pandorabox.io"
+     COOKIE_SAME_SITE: "Lax"
+     COOKIE_PREFIX: "pow-cookie"
+     DIFFICULTY_IN_JWT: "true"
+     XFF_STRIP_PRIVATE: "false"
+     TARGET: "http://pandorabox-nginx"
+     POLICY_FNAME: "/data/cfg/botPolicy.yaml"
+   healthcheck:
+     test: ["CMD", "anubis", "--healthcheck"]
+     interval: 5s
+     timeout: 30s
+     retries: 5
+     start_period: 500ms
+   volumes:
+     - "./botPolicy.yaml:/data/cfg/botPolicy.yaml:ro"
+     - "./data/anubis:/data"
+   labels:
+    - "traefik.enable=true"
+    - "traefik.docker.network=terminator"
+    - "traefik.http.routers.pandorabox.rule=Host(`pandorabox.io`)"
+    - "traefik.http.services.pandorabox.loadbalancer.server.port=8080"
+    - "traefik.http.routers.pandorabox.entrypoints=websecure"
+    - "traefik.http.routers.pandorabox.tls.certresolver=default"
 
 volumes:
  postgres_socket: {}


### PR DESCRIPTION
there are quite a few (ai and other) bots scraping the wiki page and creating unnecessary load

this PR adds anubis with a default botpolicy which should only block bots for now.

this also solves the round-robin engine metrics issue [here](https://monitoring.luanti.ch/d/BRwIg8xMz/engine-metrics?orgId=1&from=now-1h&to=now&timezone=browser&var-instance=bananaland.minetest.ch&refresh=5s)